### PR TITLE
Travis CI integration on Mac + Code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
+sudo: false
 matrix:
   include:
     - os: linux
       python: 3.5
-      sudo: false
     - os: osx
       language: generic
       env: PYTHON_INSTALLER=brew

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
       language: generic
       env: PYTHON_INSTALLER=pyenv TRAVIS_PYTHON_VERSION=3.6.4
 sudo: false
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm get head; fi
 install:
   - source .travis/install.sh
   - pip install nose

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
 sudo: false
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm get head; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm get stable; fi
 install:
   - source .travis/install.sh
   - pip install nose

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,14 @@ matrix:
   include:
     - os: linux
       python: 3.5
+      sudo: false
     - os: osx
       language: generic
       env: PYTHON_INSTALLER=brew
     - os: osx
       language: generic
       env: PYTHON_INSTALLER=pyenv TRAVIS_PYTHON_VERSION=3.6.4
-sudo: false
 
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvmsudo rvm get stable; fi
 install:
   - source .travis/install.sh
   - pip install nose

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
 sudo: false
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm get stable; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvmsudo rvm get stable; fi
 install:
   - source .travis/install.sh
   - pip install nose

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ install:
   - python setup.py install
   - cd ../..
 script:
-  - python setup.py nosetests -s --with-coverage
+  - python setup.py nosetests -s --with-coverage --cover-package=ament_tools
+after_script:
+  - codecov
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 install:
   - source .travis/install.sh
   - pip install nose
-  - pip install flake8 pydocstyle
+  - pip install flake8 pydocstyle codecov
 # For now install ament_package from git
   - git clone https://github.com/ament/ament_package.git
   - cd ament_package
@@ -37,6 +37,6 @@ install:
   - python setup.py install
   - cd ../..
 script:
-  - python setup.py nosetests -s
+  - python setup.py nosetests -s --with-coverage
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: python
-python:
-#  - "2.7"
-  - "3.5"
+matrix:
+  include:
+    - os: linux
+      python: 3.5
+    - os: osx
+      language: generic
+      env: PYTHON_INSTALLER=brew
+    - os: osx
+      language: generic
+      env: PYTHON_INSTALLER=pyenv TRAVIS_PYTHON_VERSION=3.6.4
 sudo: false
 install:
+  - source .travis/install.sh
   - pip install nose
   - pip install flake8 pydocstyle
 # For now install ament_package from git

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -5,6 +5,12 @@ do_install()
     set -e
     set -x
 
+    if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+        # workaround ugly warning on travis OSX,
+        # see https://github.com/direnv/direnv/issues/210
+        shell_session_update() { :; }
+    fi
+
     if [[ $TRAVIS_OS_NAME == 'osx' && $PYTHON_INSTALLER == 'pyenv' ]]; then
         brew install pyenv-virtualenv
         pyenv versions

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -14,6 +14,8 @@ do_install()
         pyenv activate $PYTHON_ENV_NAME
 
     elif [[ $TRAVIS_OS_NAME == 'osx' && $PYTHON_INSTALLER == 'brew' ]]; then
+        brew list
+        brew install python3
         # nose 1.3.7 creates /usr/local/man dir if it does not exist.
         # The operation fails because current user does not own /usr/local.  Create the dir manually instead.
         sudo mkdir /usr/local/man

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -20,8 +20,9 @@ do_install()
         brew upgrade python3
         # nose 1.3.7 creates /usr/local/man dir if it does not exist.
         # The operation fails because current user does not own /usr/local.  Create the dir manually instead.
-        # sudo mkdir /usr/local/man
-        # sudo chown -R $(whoami) $(brew --prefix)/*
+        # More at https://github.com/nose-devs/nose/issues/1017
+        sudo mkdir /usr/local/man
+        sudo chown -R $(whoami) $(brew --prefix)/*
 
         export PATH=$(pwd)/.travis/shim:$PATH
     fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -27,6 +27,8 @@ do_install()
 #        mkdir -p ~/Library/Python/2.7/lib/python/site-packages
 #        echo "$(brew --prefix)/lib/python2.7/site-packages" >> ~/Library/Python/2.7/lib/python/site-packages/homebrew.pth
     fi
+
+    set +e
 }
 
 do_install

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
+set -x
+
 do_install()
 {
     set -e
-    set -x
 
     if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
         # workaround ugly warning on travis OSX,

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -3,6 +3,7 @@
 do_install()
 {
     set -e
+    set -x
 
     if [[ $TRAVIS_OS_NAME == 'osx' && $PYTHON_INSTALLER == 'pyenv' ]]; then
         brew install pyenv-virtualenv
@@ -15,7 +16,7 @@ do_install()
 
     elif [[ $TRAVIS_OS_NAME == 'osx' && $PYTHON_INSTALLER == 'brew' ]]; then
         brew list
-        brew install python3
+        brew upgrade python3
         # nose 1.3.7 creates /usr/local/man dir if it does not exist.
         # The operation fails because current user does not own /usr/local.  Create the dir manually instead.
         sudo mkdir /usr/local/man
@@ -25,6 +26,8 @@ do_install()
 #        mkdir -p ~/Library/Python/2.7/lib/python/site-packages
 #        echo "$(brew --prefix)/lib/python2.7/site-packages" >> ~/Library/Python/2.7/lib/python/site-packages/homebrew.pth
     fi
+
+    set +x
 }
 
 do_install

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+do_install()
+{
+    set -e
+
+    if [[ $TRAVIS_OS_NAME == 'osx' && $PYTHON_INSTALLER == 'pyenv' ]]; then
+        brew install pyenv-virtualenv
+        pyenv versions
+        eval "$(pyenv init -)"
+        pyenv install $TRAVIS_PYTHON_VERSION
+        PYTHON_ENV_NAME=virtual-env-$TRAVIS_PYTHON_VERSION
+        pyenv virtualenv $TRAVIS_PYTHON_VERSION $PYTHON_ENV_NAME
+        pyenv activate $PYTHON_ENV_NAME
+
+    elif [[ $TRAVIS_OS_NAME == 'osx' && $PYTHON_INSTALLER == 'brew' ]]; then
+        # nose 1.3.7 creates /usr/local/man dir if it does not exist.
+        # The operation fails because current user does not own /usr/local.  Create the dir manually instead.
+        sudo mkdir /usr/local/man
+        sudo chown -R $(whoami) $(brew --prefix)/*
+
+        export PATH=$(pwd)/.travis/shim:$PATH
+#        mkdir -p ~/Library/Python/2.7/lib/python/site-packages
+#        echo "$(brew --prefix)/lib/python2.7/site-packages" >> ~/Library/Python/2.7/lib/python/site-packages/homebrew.pth
+    fi
+}
+
+do_install

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -32,8 +32,6 @@ do_install()
 #        mkdir -p ~/Library/Python/2.7/lib/python/site-packages
 #        echo "$(brew --prefix)/lib/python2.7/site-packages" >> ~/Library/Python/2.7/lib/python/site-packages/homebrew.pth
     fi
-
-    set +x
 }
 
 do_install

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -6,10 +6,6 @@ do_install()
 {
     set -e
 
-    if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-        rvm get head # https://github.com/travis-ci/travis-ci/issues/6307
-    fi
-
     if [[ $TRAVIS_OS_NAME == 'osx' && $PYTHON_INSTALLER == 'pyenv' ]]; then
         brew install pyenv-virtualenv
         pyenv versions

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -20,12 +20,10 @@ do_install()
         brew upgrade python3
         # nose 1.3.7 creates /usr/local/man dir if it does not exist.
         # The operation fails because current user does not own /usr/local.  Create the dir manually instead.
-        sudo mkdir /usr/local/man
-        sudo chown -R $(whoami) $(brew --prefix)/*
+        # sudo mkdir /usr/local/man
+        # sudo chown -R $(whoami) $(brew --prefix)/*
 
         export PATH=$(pwd)/.travis/shim:$PATH
-#        mkdir -p ~/Library/Python/2.7/lib/python/site-packages
-#        echo "$(brew --prefix)/lib/python2.7/site-packages" >> ~/Library/Python/2.7/lib/python/site-packages/homebrew.pth
     fi
 
     set +e

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -7,9 +7,7 @@ do_install()
     set -e
 
     if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-        # workaround ugly warning on travis OSX,
-        # see https://github.com/direnv/direnv/issues/210
-        shell_session_update() { :; }
+        rvm get head # https://github.com/travis-ci/travis-ci/issues/6307
     fi
 
     if [[ $TRAVIS_OS_NAME == 'osx' && $PYTHON_INSTALLER == 'pyenv' ]]; then

--- a/.travis/shim/pip
+++ b/.travis/shim/pip
@@ -1,0 +1,6 @@
+#!/bin/sh
+# This wrapper allows installation to call pip and it actually be
+# the pip3 that's part of brewed Python, rather than the missing
+# system pip.
+pip3 $@
+exit $?

--- a/.travis/shim/python
+++ b/.travis/shim/python
@@ -1,3 +1,3 @@
 #!/bin/sh
-pip3 $@
+python3 $@
 exit $?

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     version='0.4.0',
     packages=find_packages(exclude=['test', 'test.*']),
     install_requires=['ament-package', 'osrf_pycommon'],
+    zip_safe=False,
     data_files=[
         ('share/ament_tools/environment',
             [


### PR DESCRIPTION
Run the process on OCX with 2 versions of python - python3 from brew, and python 3.6.4 from pyenv.

Get code coverage numbers and upload them to CodeCov service.